### PR TITLE
Split comments on blank lines

### DIFF
--- a/src/IniReader.php
+++ b/src/IniReader.php
@@ -166,6 +166,11 @@ class IniReader
                 continue;
             }
 
+            if ($line === '') {
+                $lastComment = "\n";
+                continue;
+            }
+
             if (!preg_match('/^[a-zA-Z0-9[]/', $line)) {
                 if (strpos($line, ';') === 0) {
                     $line = trim(substr($line, 1));

--- a/tests/resources/test.ini.php
+++ b/tests/resources/test.ini.php
@@ -32,10 +32,16 @@ test_key8[] = "default1"
 test_key8[] = "default2"
 test_key9 = "c3.large"
 
+; Lorem ipsum
+; test_key10 = 1
+
 [log]
 ; Fusce maximus bibendum lectus, nec tristique enim malesuada hendrerit.
 log_writers[] = screen
 log_writers[] = file
+
+; Lorem ipsum
+; log_file = "foo.log"
 
 ; Quisque lorem justo, sollicitudin at pellentesque interdum, euismod quis nulla.
 ; Sed malesuada dolor in tempus ornare. Etiam lobortis commodo congue.


### PR DESCRIPTION
Ini files often contains documentation for settings that are commented out.

In the example below, the description of  `instance_id` should obviously not be included in the description of `api_service_url`.

This PR changes the parser, so that comments are broken on empty lines.

Example:
```
; If you use this Matomo instance over multiple hostnames, Matomo will need to know
; a unique instance_id for this instance, so that Matomo can serve the right custom logo and tmp/* assets,
; independently of the hostname Matomo is currently running under.
; instance_id = stats.example.com

; The API server is an essential part of the Matomo infrastructure/ecosystem to
; provide services to Matomo installations, e.g., getLatestVersion and
; subscribeNewsletter.
api_service_url = http://api.matomo.org
```