### PR TITLE
don't use deprecated array syntax

### DIFF
--- a/src/IniReader.php
+++ b/src/IniReader.php
@@ -238,7 +238,7 @@ class IniReader
             }
 
             // Sections
-            if ($line{0} == '[') {
+            if ($line[0] == '[') {
                 $tmp = explode(']', $line);
                 $sections[] = trim(substr($tmp[0], 1));
                 $i++;
@@ -252,16 +252,16 @@ class IniReader
             if (strstr($value, ";")) {
                 $tmp = explode(';', $value);
                 if (count($tmp) == 2) {
-                    if ((($value{0} != '"') && ($value{0} != "'")) ||
+                    if ((($value[0] != '"') && ($value[0] != "'")) ||
                         preg_match('/^".*"\s*;/', $value) || preg_match('/^".*;[^"]*$/', $value) ||
                         preg_match("/^'.*'\s*;/", $value) || preg_match("/^'.*;[^']*$/", $value)
                     ) {
                         $value = $tmp[0];
                     }
                 } else {
-                    if ($value{0} == '"') {
+                    if ($value[0] == '"') {
                         $value = preg_replace('/^"(.*)".*/', '$1', $value);
-                    } elseif ($value{0} == "'") {
+                    } elseif ($value[0] == "'") {
                         $value = preg_replace("/^'(.*)'.*/", '$1', $value);
                     } else {
                         $value = $tmp[0];


### PR DESCRIPTION
for PHP 7.4 compatibility
See matomo-org/matomo#14821 (comment) for more details.

Interestingly this is the same code as in 
https://github.com/matomo-org/matomo/blob/7ef892665d8e51471a0eb3fa93a4b0f9967278b7/libs/upgradephp/upgrade.php#L138 so I guess the function can be removed there.