### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 dist: trusty
@@ -18,12 +20,12 @@ matrix:
 before_script:
   - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g -- disable-tls true || true'
   - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && composer config -g -- secure-http false || true'
-  - if [[ $(phpenv version-name) == '5.6' ]]; then composer require satooshi/php-coveralls:2.0.x-dev -n ; fi
+  - if [[ $(phpenv version-name) == '5.6' ]]; then composer require php-coveralls/php-coveralls:^2.1 -n ; fi
   - if [[ $(phpenv version-name) != '5.6' ]]; then composer install -n ; fi
 
 script:
-  - if [[ $(phpenv version-name) == '5.6' ]]; then $TRAVIS_BUILD_DIR/vendor/phpunit/phpunit/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $(phpenv version-name) != '5.6' ]]; then $TRAVIS_BUILD_DIR/vendor/phpunit/phpunit/phpunit ; fi
+  - if [[ $(phpenv version-name) == '5.6' ]]; then $TRAVIS_BUILD_DIR/vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ $(phpenv version-name) != '5.6' ]]; then $TRAVIS_BUILD_DIR/vendor/bin/phpunit ; fi
 
 after_script:
   - if [[ $(phpenv version-name) == '5.6' ]]; then php vendor/bin/coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^4.8.36",
         "athletic/athletic": "0.1.*"
     }
 }

--- a/tests/BaseIniReaderTest.php
+++ b/tests/BaseIniReaderTest.php
@@ -9,15 +9,16 @@
 namespace Matomo\Tests\Ini;
 
 use Matomo\Ini\IniReader;
+use PHPUnit\Framework\TestCase;
 
-abstract class BaseIniReaderTest extends \PHPUnit_Framework_TestCase
+abstract class BaseIniReaderTest extends TestCase
 {
     /**
      * @var IniReader
      */
     protected $reader;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/IniReaderDisabledFunctionTest.php
+++ b/tests/IniReaderDisabledFunctionTest.php
@@ -13,7 +13,7 @@ namespace Matomo\Tests\Ini;
  */
 class IniReaderDisableFunctionTest extends BaseIniReaderTest
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/IniWriterTest.php
+++ b/tests/IniWriterTest.php
@@ -9,8 +9,9 @@
 namespace Matomo\Tests\Ini;
 
 use Matomo\Ini\IniWriter;
+use PHPUnit\Framework\TestCase;
 
-class IniWriterTest extends \PHPUnit_Framework_TestCase
+class IniWriterTest extends TestCase
 {
     public function test_writeToString()
     {


### PR DESCRIPTION
# Changed log
- Add `php-7.2` and `php-7.3` tests on Travis CI build.
- The ` satooshi/php-coveralls` package is deprecated, and using the `php-coveralls/php-coveralls` instead.
- Using the `vendor/bin/phpunit` to execute `PHPUnit`.
- To support future stable `PHPUnit` version easily, upgrading the `PHPUnit` to `^4.8.36` version.
- Using the `PHPUnit` class namespace.
- According to the `PHPUnit fixture` reference, it should be the `protected setUp` method.