### PR TITLE
Don't use rawValues if raw scanner fails to parse the ini file

### DIFF
--- a/src/IniReader.php
+++ b/src/IniReader.php
@@ -104,6 +104,10 @@ class IniReader
         // We cannot use INI_SCANNER_RAW by default because it is buggy under PHP 5.3.14 and 5.4.4
         // http://3v4l.org/m24cT
         $rawValues = @parse_ini_string($ini, true, INI_SCANNER_RAW);
+        if ($rawValues === false) {
+            return $this->decode($array, $array);
+        }
+
         $array = $this->decode($array, $rawValues);
 
         return $array;


### PR DESCRIPTION
In some cases (such as when the ini file contains multi-line strings),
parse_ini_file with the INI_SCANNER_RAW flag causes the parse to fail.
This in turn leads to a lot of noise in error logs because the
subsequent call to decode throws a lot of E_NOTICEs. If the parse fails,
just use what was processed by parse_ini_file directly instead.

See matomo-org/matomo#15689 for additional context.