### PR TITLE
Switch to custom reader implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ $array = $reader->readString($string);
 $array = $reader->readFile('config.ini');
 ```
 
+#### Troubleshooting
+
+**unexpected BOOL_TRUE in Unknown on line X**
+
+The PHP default implementation of read_ini_file does not allow bool-ish values as keys in when reading ini files.
+
+Data like `yes = "Yes"` results in the following error:
+
+```
+Syntax error in INI configuration: syntax error, unexpected BOOL_TRUE in Unknown on line 6
+```
+
+To prevent from that error, please switch to the custom ini reader implementation by using:
+
+```php
+$reader = new IniReader();
+$reader->setUseNativeFunction(false);
+```
+
+
 ### Write
 
 ```php

--- a/src/IniReader.php
+++ b/src/IniReader.php
@@ -395,4 +395,24 @@ class IniReader
     {
         return (string) ($value + 0) === $value;
     }
+
+    /**
+     * @return bool
+     */
+    public function isUseNativeFunction()
+    {
+        return $this->useNativeFunction;
+    }
+
+    /**
+     * @param bool $useNativeFunction
+     *
+     * @return IniReader
+     */
+    public function setUseNativeFunction($useNativeFunction)
+    {
+        $this->useNativeFunction = $useNativeFunction;
+
+        return $this;
+    }
 }

--- a/tests/BaseIniReaderTest.php
+++ b/tests/BaseIniReaderTest.php
@@ -253,6 +253,16 @@ INI;
         $this->reader->readFile('/foobar');
     }
 
+    /**
+     * @expectedException \Matomo\Ini\IniReadingException
+     * @expectedExceptionMessage unexpected BOOL_TRUE
+     */
+    public function test_readBoolKeysError()
+    {
+        $this->reader->setUseNativeFunction(true);
+        $this->reader->readFile(__DIR__ . '/resources/BoolKey.ini');
+    }
+
     public function test_readBoolKeys()
     {
         $expected = array(

--- a/tests/BaseIniReaderTest.php
+++ b/tests/BaseIniReaderTest.php
@@ -252,4 +252,22 @@ INI;
     {
         $this->reader->readFile('/foobar');
     }
+
+    public function test_readBoolKeys()
+    {
+        $expected = array(
+            'form-edit'         => array(
+                'submit' => 'Submit',
+                'cancel' => 'Cancel',
+            ),
+            'form-confirmation' => array(
+                'yes' => 'Yes',
+                'no'  => 'No',
+            ),
+        );
+        $this->reader->setUseNativeFunction(false);
+        $result   = $this->reader->readFile(__DIR__ . '/resources/BoolKey.ini');
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/resources/BoolKey.ini
+++ b/tests/resources/BoolKey.ini
@@ -1,0 +1,7 @@
+[form-edit]
+submit = "Submit"
+cancel = "Cancel"
+
+[form-confirmation]
+yes = "Yes"
+no = "No"


### PR DESCRIPTION
The PHP default reader implementation raises an error, when the input file contains "bool-ish" values as keys, like 

```
yes = "Yes"
```

This PR allowes to manually switch to custom reader implementation even if `parse_ini_string` function is enabled.