### PR TITLE
exclude encode for username and password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor/
 /coverage/
 /clover.xml
+.idea/**

--- a/src/IniWriter.php
+++ b/src/IniWriter.php
@@ -107,7 +107,11 @@ class IniWriter
                             $ini .= $this->encodeKey($option) . '[' . $this->encodeKey($key) . '] = ' . $this->encodeValue($currentValue) . "\n";
                         }
                     }
-                } else {
+                } elseif (in_array($option, $excludeEncodeKey)) {
+                    $ini .= $option . ' = ' .$value . "\n";
+
+                }
+                else {
                     $ini .= $option . ' = ' . $this->encodeValue($value) . "\n";
                 }
             }

--- a/src/IniWriter.php
+++ b/src/IniWriter.php
@@ -87,6 +87,10 @@ class IniWriter
             $sectionName = $this->encodeSectionName($sectionName);
             $ini .= "[$sectionName]\n";
 
+            //we don't encode certain field in config file eg: password, username
+            $excludeEncodeKey = ['password', 'username'];
+
+
             foreach ($section as $option => $value) {
                 if (is_numeric($option)) {
                     $option = $sectionName;
@@ -97,6 +101,8 @@ class IniWriter
                     foreach ($value as $key => $currentValue) {
                         if (is_int($key)) {
                             $ini .= $this->encodeKey($option) . '[] = ' . $this->encodeValue($currentValue) . "\n";
+                        } elseif (in_array($key, $excludeEncodeKey)) {
+                            $ini .= $this->encodeKey($option) . '[' . $this->encodeKey($key) . '] = ' . $currentValue . "\n";
                         } else {
                             $ini .= $this->encodeKey($option) . '[' . $this->encodeKey($key) . '] = ' . $this->encodeValue($currentValue) . "\n";
                         }

--- a/tests/IniWriterTest.php
+++ b/tests/IniWriterTest.php
@@ -114,4 +114,26 @@ INI;
         $writer = new IniWriter();
         $this->assertEquals($expected, $writer->writeToString($config, $header));
     }
+    public function test_writeToString_shouldSkipPasswordAndUsername()
+    {
+        $header = "; <?php exit; ?> DO NOT REMOVE THIS LINE\n";
+        $config = array(
+            'Section 1' => array(
+                'username'=>"'!@#$%^&*()_+[]{}",
+                'password' => "bar'",
+            ),
+        );
+        $expected = <<<INI
+; <?php exit; ?> DO NOT REMOVE THIS LINE
+[Section 1]
+username = '!@#$%^&*()_+[]{}
+password = bar'
+
+
+INI;
+        $writer = new IniWriter();
+        $this->assertEquals($expected, $writer->writeToString($config, $header));
+    }
+
+
 }


### PR DESCRIPTION
### Description:
Fixes : https://github.com/matomo-org/matomo/issues/19899
Hard coded `password` and `username` skip encode. 
### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
