### PR TITLE
Use bash syntax for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read and write INI configurations.
 
 ## Installation
 
-```json
+```bash
 composer require matomo/ini
 ```
 


### PR DESCRIPTION
A safe change in the used syntax highlighter for installation instructions in the main README file.
